### PR TITLE
Fix: use nodemailer.createTransport instead of createTransporter

### DIFF
--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -18,7 +18,7 @@ class EmailService {
 
   initializeTransporter() {
     try {
-      this.transporter = nodemailer.createTransporter({
+      this.transporter = nodemailer.createTransport({
         host: this.config.email.smtp.host,
         port: this.config.email.smtp.port,
         secure: this.config.email.smtp.secure,


### PR DESCRIPTION
Failed to initialize email service: nodemailer.createTransporter is not a function